### PR TITLE
Refactor f2py data tests for clarity

### DIFF
--- a/numpy/f2py/tests/test_data.py
+++ b/numpy/f2py/tests/test_data.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 from numpy.f2py.crackfortran import crackfortran
 
 from . import util
@@ -12,28 +13,49 @@ class TestData(util.F2PyTest):
     # For gh-23276
     @pytest.mark.slow
     def test_data_stmts(self):
-        assert self.module.cmplxdat.i == 2
-        assert self.module.cmplxdat.j == 3
-        assert self.module.cmplxdat.x == 1.5
-        assert self.module.cmplxdat.y == 2.0
-        assert self.module.cmplxdat.pi == 3.1415926535897932384626433832795028841971693993751058209749445923078164062
-        assert self.module.cmplxdat.medium_ref_index == np.array(1. + 0.j)
-        assert np.all(self.module.cmplxdat.z == np.array([3.5, 7.0]))
-        assert np.all(self.module.cmplxdat.my_array == np.array([ 1. + 2.j, -3. + 4.j]))
-        assert np.all(self.module.cmplxdat.my_real_array == np.array([ 1., 2., 3.]))
-        assert np.all(self.module.cmplxdat.ref_index_one == np.array([13.0 + 21.0j]))
-        assert np.all(self.module.cmplxdat.ref_index_two == np.array([-30.0 + 43.0j]))
+        scalars = {
+            "i": 2,
+            "j": 3,
+            "x": 1.5,
+            "y": 2.0,
+            "pi": 3.1415926535897932384626433832795028841971693993751058209749445923078164062,
+        }
+
+        for name, expected in scalars.items():
+            assert getattr(self.module.cmplxdat, name) == expected
+
+        assert_array_equal(
+            self.module.cmplxdat.medium_ref_index, np.array(1.0 + 0.0j)
+        )
+        assert_array_equal(self.module.cmplxdat.z, np.array([3.5, 7.0]))
+        assert_array_equal(
+            self.module.cmplxdat.my_array, np.array([1.0 + 2.0j, -3.0 + 4.0j])
+        )
+        assert_array_equal(
+            self.module.cmplxdat.my_real_array, np.array([1.0, 2.0, 3.0])
+        )
+        assert_array_equal(
+            self.module.cmplxdat.ref_index_one, np.array([13.0 + 21.0j])
+        )
+        assert_array_equal(
+            self.module.cmplxdat.ref_index_two, np.array([-30.0 + 43.0j])
+        )
 
     def test_crackedlines(self):
         mod = crackfortran(self.sources)
-        assert mod[0]['vars']['x']['='] == '1.5'
-        assert mod[0]['vars']['y']['='] == '2.0'
-        assert mod[0]['vars']['pi']['='] == '3.1415926535897932384626433832795028841971693993751058209749445923078164062d0'
-        assert mod[0]['vars']['my_real_array']['='] == '(/1.0d0, 2.0d0, 3.0d0/)'
-        assert mod[0]['vars']['ref_index_one']['='] == '(13.0d0, 21.0d0)'
-        assert mod[0]['vars']['ref_index_two']['='] == '(-30.0d0, 43.0d0)'
-        assert mod[0]['vars']['my_array']['='] == '(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)'
-        assert mod[0]['vars']['z']['='] == '(/3.5,  7.0/)'
+        expected = {
+            "x": "1.5",
+            "y": "2.0",
+            "pi": "3.1415926535897932384626433832795028841971693993751058209749445923078164062d0",
+            "my_real_array": "(/1.0d0, 2.0d0, 3.0d0/)",
+            "ref_index_one": "(13.0d0, 21.0d0)",
+            "ref_index_two": "(-30.0d0, 43.0d0)",
+            "my_array": "(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)",
+            "z": "(/3.5,  7.0/)",
+        }
+
+        for var, value in expected.items():
+            assert mod[0]["vars"][var]["="] == value
 
 class TestDataF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_common.f")]
@@ -44,8 +66,7 @@ class TestDataF77(util.F2PyTest):
 
     def test_crackedlines(self):
         mod = crackfortran(str(self.sources[0]))
-        print(mod[0]['vars'])
-        assert mod[0]['vars']['mydata']['='] == '0'
+        assert mod[0]["vars"]["mydata"]["="] == "0"
 
 
 class TestDataMultiplierF77(util.F2PyTest):
@@ -53,11 +74,16 @@ class TestDataMultiplierF77(util.F2PyTest):
 
     # For gh-23276
     def test_data_stmts(self):
-        assert self.module.mycom.ivar1 == 3
-        assert self.module.mycom.ivar2 == 3
-        assert self.module.mycom.ivar3 == 2
-        assert self.module.mycom.ivar4 == 2
-        assert self.module.mycom.evar5 == 0
+        expected = {
+            "ivar1": 3,
+            "ivar2": 3,
+            "ivar3": 2,
+            "ivar4": 2,
+            "evar5": 0,
+        }
+
+        for name, value in expected.items():
+            assert getattr(self.module.mycom, name) == value
 
 
 class TestDataWithCommentsF77(util.F2PyTest):
@@ -65,7 +91,7 @@ class TestDataWithCommentsF77(util.F2PyTest):
 
     # For gh-23276
     def test_data_stmts(self):
-        assert len(self.module.mycom.mytab) == 3
-        assert self.module.mycom.mytab[0] == 0
-        assert self.module.mycom.mytab[1] == 4
-        assert self.module.mycom.mytab[2] == 0
+        assert_array_equal(
+            self.module.mycom.mytab,
+            np.array([0, 4, 0], dtype=self.module.mycom.mytab.dtype),
+        )


### PR DESCRIPTION
## Summary
- improve array assertions and remove debug print in f2py data tests
- parameterize repeated checks for data statements and cracked lines

## Testing
- `pre-commit run --files numpy/f2py/tests/test_data.py` *(fails: command not found)*
- `pytest numpy/f2py/tests/test_data.py -q` *(fails: ImportError: cannot import name 'version')*


------
https://chatgpt.com/codex/tasks/task_b_68b8602a45a883338b30a662a118771e