### PR TITLE
Fix XGBoost multi-output handling and add dependency auto-installation

### DIFF
--- a/tools/lottery_pipeline.py
+++ b/tools/lottery_pipeline.py
@@ -224,13 +224,10 @@ def _scrape_lotteryusa(scraper: LotteryScraper, start_year: Optional[int], end_y
         url = f"https://www.lotteryusa.com/{slug}/year/{year}/"
         response = requests.get(url, timeout=30)
         if response.status_code == 404:
-            if start_year is not None:
+            year -= 1
+            if year < lower_bound:
                 break
-            if year == current_year:
-                year -= 1
-                continue
-            else:
-                break
+            continue
         response.raise_for_status()
         tables = pd.read_html(response.text)
         if not tables:


### PR DESCRIPTION
## Summary
- wrap the tuned XGBoost regressor in MultiOutputRegressor so multi-ball targets train correctly
- update stacking helper signatures to accept the multi-output estimator
- keep the ensemble mode result vector intact when converting to integers
- add on-demand dependency auto-installation with CLI/environment switches for upgrade control
- respect the requested LotteryUSA archive year range instead of stopping after the first missing page

## Testing
- python -m py_compile tools/lottery_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b8ab0ffd88333b349acf77f041f1c)