### PR TITLE
Respect start-year bounds when scraping LotteryUSA archives

### DIFF
--- a/tools/lottery_pipeline.py
+++ b/tools/lottery_pipeline.py
@@ -209,7 +209,9 @@ def _scrape_lotteryusa(scraper: LotteryScraper, start_year: Optional[int], end_y
     if end_year is not None:
         first_year = min(end_year, current_year)
     elif start_year is not None:
-        first_year = min(start_year, current_year)
+        # When only a lower bound is provided, start from the most recent year
+        # and work backward until the requested start year.
+        first_year = current_year
     else:
         # LotteryUSA typically stores archives back to early years.  To avoid
         # excessive traffic we probe backwards until we encounter an HTTP 404.


### PR DESCRIPTION
## Summary
- start LotteryUSA archive scraping from the current year when only a lower bound is provided
- continue iterating backwards to honor requested start/end year ranges instead of stopping after a single year

## Testing
- python -m py_compile tools/lottery_pipeline.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b8ffeb7848333bade4dbe313895f3)